### PR TITLE
page: download: always show buttons on smaller screens

### DIFF
--- a/components/MirrorItem.vue
+++ b/components/MirrorItem.vue
@@ -5,7 +5,7 @@ const props = defineProps({
 </script>
 
 <template>
-  <v-list-item>
+  <v-list-item class="mirror-list-item">
     <v-list-item-title>
       {{ mirror.name }}
     </v-list-item-title>
@@ -38,7 +38,6 @@ const props = defineProps({
             variant="text"
             icon="mdi-minidisc"
             v-bind="props"
-            class="hidden-sm-and-down"
           ></v-btn>
         </template>
       </v-tooltip>
@@ -48,7 +47,6 @@ const props = defineProps({
             :disabled="mirror.tags.includes('Images Only')"
             :href="mirror.nolistdir ? mirror.url : mirror.url + '/eweos/'"
             variant="text"
-            class="hidden-xs"
             icon="mdi-package"
             v-bind="props"
           ></v-btn>
@@ -57,3 +55,18 @@ const props = defineProps({
     </template>
   </v-list-item>
 </template>
+
+<style scoped>
+@media (max-width: 600px) {
+  .mirror-list-item {
+    grid-template-columns: max-content 1fr;
+    grid-template-rows: repeat(2, auto);
+    grid-template-areas: "prepend content";
+  }
+
+  .mirror-list-item>:deep(.v-list-item__append) {
+    grid-column: 2;
+  }
+}
+</style>
+

--- a/components/MirrorTrafficStatsVnstatiDialog.vue
+++ b/components/MirrorTrafficStatsVnstatiDialog.vue
@@ -4,7 +4,6 @@
       <v-btn
         variant="text"
         icon="mdi-chart-line"
-        class="hidden-sm-and-down"
         v-bind="activatorProps"
       >
       </v-btn>


### PR DESCRIPTION
Some buttons would disappear on mobile phones because of hidden-* classes appended in tooltips.

By patching grid-* props it's now able to display a better interface while keeping everything shown, dynamically controlled by @media selectors, similar to vuetify.

This commit uses ':deep()' feature from Vue to patch the default behaviour.